### PR TITLE
Ensure 'alias' resources are expanded

### DIFF
--- a/resource.md
+++ b/resource.md
@@ -24,6 +24,10 @@ sidebarDepth: 0
 {{/each}}
 {{/if}}
 
+{{#if (eq type "string")}}Type: {{ type }}{{/if}}
+
+{{#if enum }}Enum: <ul>{{#each enum }}<li>`{{ this }}`</li>{{/each}}</ul>{{/if}}
+
 {{#if example }}
 ##### Example
 ```json


### PR DESCRIPTION
This change ensures the real type is shown in the resource.md markdown file.