### PR TITLE
Markdown table: expand an additional level of properties

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -1,8 +1,9 @@
 {{#*inline "typeDetails" key property required }}
 {{#if (and (eq property.type 'array') (ne property.items.$ref undefined)) }} of [{{ refToResourceName property.items.$ref }}]({{ refToResourceLink property.items.$ref }}){{/if ~}}
-{{#if (and (ne property.type 'array') (ne property.$ref undefined)) }} object [{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
+{{#if (and (eq property.type 'object') (ne property.$ref undefined)) }} object [{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
+{{#if (and (eq property.type undefined) (ne property.$ref undefined)) }}[{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
 {{#if (in key required) }}<br />_**required**_{{/if ~}}
-{{#if property.enum ~}}<br /><br />Enum: <ul>{{#each property.enum }}<li>`{{ this }}`</li>{{/each}}</ul>{{/if ~}}
+{{#if property.enum }}<br /><br />Enum: <ul>{{#each property.enum }}<li>`{{ this }}`</li>{{/each}}</ul>{{/if ~}}
 {{/inline}}
 
 {{#*inline "row" key property required }}

--- a/resource.md
+++ b/resource.md
@@ -3,9 +3,10 @@ sidebarDepth: 0
 ---
 {{#*inline "typeDetails" key property required }}
 {{#if (and (eq property.type 'array') (ne property.items.$ref undefined)) }} of [{{ refToResourceName property.items.$ref }}]({{ refToResourceLink property.items.$ref }}){{/if ~}}
-{{#if (and (ne property.type 'array') (ne property.$ref undefined)) }} object [{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
+{{#if (and (eq property.type 'object') (ne property.$ref undefined)) }} object [{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
+{{#if (and (eq property.type undefined) (ne property.$ref undefined)) }}[{{ refToResourceName property.$ref }}]({{ refToResourceLink property.$ref }}){{/if ~}}
 {{#if (in key required) }}<br />_**required**_{{/if ~}}
-{{#if property.enum }}<br /><br />Enum: <ul>{{#each property.enum }}<li>`{{ this }}`</li>{{/each}} </ul>{{/if ~}}
+{{#if property.enum }}<br /><br />Enum: <ul>{{#each property.enum }}<li>`{{ this }}`</li>{{/each}}</ul>{{/if ~}}
 {{/inline}}
 
 {{#*inline "row" key property required }}

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -285,7 +285,7 @@ function requestBodyObjects(
     const schemaObject = object as OpenAPIV3.SchemaObject
 
     return {
-        requestBodySchema: resolveSchemaOrReferenceObject(schemaObject, refs, 1),
+        requestBodySchema: resolveSchemaOrReferenceObject(schemaObject, refs, 2),
         requestBodyExample: buildExampleTree(schemaObject, refs),
         requestBodyRef: refObject.$ref,
     }


### PR DESCRIPTION
This change expands an additional level of openapi's schema object tree to display
an additional level or properties and only "link-back" at the third
level.