### PR TITLE
Fix resolveAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fix": "yarn run eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "build": "tsc -p tsconfig.json",
     "dev": "yarn run ts-node src/openapi-vuepress-markdown.ts",
+    "pretest": "tsc -p tsconfig.json",
     "test": "jest"
   },
   "dependencies": {

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -7,7 +7,7 @@ import {
     Resource,
     ResponseSchema,
 } from './types'
-import { find, flatten, groupBy, isNil, sortBy } from 'ramda'
+import { find, flatten, groupBy, isNil, omit, sortBy } from 'ramda'
 import { readFileSync, writeFileSync } from 'fs'
 import { OpenAPIV3 } from 'openapi-types'
 
@@ -29,7 +29,6 @@ function mergeSchemaObjects(...schemaObjects: OpenAPIV3.SchemaObject[]): OpenAPI
     return schemaObjects.reduce(
         (currSchemaObject, schemaObject: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject => {
             return {
-                description: currSchemaObject.description ?? schemaObject.description,
                 ...currSchemaObject,
                 ...schemaObject,
                 properties: {
@@ -53,6 +52,7 @@ function resolveAllOf(
         return schemaObject
     }
     return mergeSchemaObjects(
+        omit(['allOf'], schemaObject) as OpenAPIV3.SchemaObject,
         ...(schemaObject.allOf as OpenAPIV3.SchemaObject[]).map(
             (childSchemaObject: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject => {
                 return resolveSchemaOrReferenceObject(

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -257,6 +257,68 @@ describe('markdownAdapters', () => {
                 },
             })
         })
+
+        test('should include fields at the same level of the allOf clause', () => {
+            const schemaObject = resolveAllOf(
+                {
+                    title: 'Title',
+                    description: 'Description',
+                    allOf: [
+                        {
+                            type: 'object',
+                            required: ['a', 'b'],
+                            properties: {
+                                a: {
+                                    type: 'string',
+                                    pattern: '^[0-9]+$',
+                                    example: '1045',
+                                },
+                                b: {
+                                    type: 'string',
+                                    description: 'foo',
+                                    enum: ['enum1', 'enum2'],
+                                },
+                            },
+                        },
+                        {
+                            type: 'object',
+                            properties: {
+                                c: {
+                                    type: 'string',
+                                    example: 'bar',
+                                },
+                            },
+                        },
+                    ],
+                },
+                createIRefsMock(),
+                undefined,
+                0,
+            )
+
+            expect(schemaObject).toEqual({
+                title: 'Title',
+                description: 'Description',
+                type: 'object',
+                required: ['a', 'b'],
+                properties: {
+                    a: {
+                        type: 'string',
+                        pattern: '^[0-9]+$',
+                        example: '1045',
+                    },
+                    b: {
+                        type: 'string',
+                        description: 'foo',
+                        enum: ['enum1', 'enum2'],
+                    },
+                    c: {
+                        type: 'string',
+                        example: 'bar',
+                    },
+                },
+            })
+        })
     })
 
     describe('resolveProperties', () => {


### PR DESCRIPTION
Ensure fields at the same level are taken into account.

For instance, in the example below, `title` and `description` are both used.
```
{
    title: 'Title',
    description: 'Desc',
    allOf: [...]
}
```

