### PR TITLE
Ensure published package is built

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: yarn install
+      - run: yarn build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-vuepress-markdown",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "This package generates vuepress compatible markdown from an openapi schema",
   "main": "./dist/openapi-vuepress-markdown.js",
   "repository": "https://github.com/lune-climate/openapi-vuepress-markdown.git",


### PR DESCRIPTION
The current published package does not contain compiled javascript files and, therefore, is unusable.