### PR TITLE
Allow endpoints and resources to have different output directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-vuepress-markdown",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "This package generates vuepress compatible markdown from an openapi schema",
   "main": "./dist/openapi-vuepress-markdown.js",
   "repository": "https://github.com/lune-climate/openapi-vuepress-markdown.git",

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -394,7 +394,8 @@ function generateResource(
 export function generateMarkdownFiles(
     api: OpenAPIV3.Document,
     refs: IRefs,
-    outputDirectory?: string,
+    endpointsDirectory?: string,
+    resourcesDirectory?: string,
 ) {
     // resources
     const schemas = api.components?.schemas as Record<string, OpenAPIV3.SchemaObject> | undefined
@@ -404,13 +405,15 @@ export function generateMarkdownFiles(
             return generateResource(name, schemaObject, refs)
         },
     )
-    resources.map((resource: Resource) => generateResourceMarkdownFile(resource, outputDirectory))
+    resources.map((resource: Resource) =>
+        generateResourceMarkdownFile(resource, resourcesDirectory),
+    )
 
     // endpoints
     const endpoints = generateEndpoints(api, refs)
     const markdownTemplatesData = groupEndpointsByTag(api, endpoints)
     markdownTemplatesData.map((markdownTemplateData) =>
-        generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory),
+        generateEndpointsMarkdownFile(markdownTemplateData, endpointsDirectory),
     )
 }
 

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -10,21 +10,25 @@ async function main(): Promise<void> {
     program
         .requiredOption('-s, --schema <schema>', 'OpenAPI spec in json or yml format')
         .option(
-            '-o, --output-directory <output-directory>',
-            'Output destination directory. If not specified, then the output is redirected to standard output',
+            '-e, --endpoints-directory <endpoints-directory>',
+            'Endpoints destination directory. If not specified, then the output is redirected to standard output',
+        )
+        .option(
+            '-r, --resources-directory <resources-directory>',
+            'Resources destination directory. If not specified, then the output is redirected to standard output',
         )
         .parse()
         .parse()
 
     const options = program.opts()
-    const { schema, outputDirectory } = options
+    const { schema, endpointsDirectory, resourcesDirectory } = options
 
     const parser = new SwaggerParser()
     // let it throw
     const api = await parser.bundle(schema)
     const refs = parser.$refs
 
-    generateMarkdownFiles(api, refs, outputDirectory)
+    generateMarkdownFiles(api, refs, endpointsDirectory, resourcesDirectory)
 }
 
 // eslint-disable-next-line no-extra-semi


### PR DESCRIPTION
This same directory is still possible, this allows for greater flexibility.

Previously, endpoints and resources would overwrite each other if they resulted in the same markdown filename.

Bump version to 0.0.9.