### PR TITLE
Support optional prefix for endpoints markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-vuepress-markdown",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "This package generates vuepress compatible markdown from an openapi schema",
   "main": "./dist/openapi-vuepress-markdown.js",
   "repository": "https://github.com/lune-climate/openapi-vuepress-markdown.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-vuepress-markdown",
-  "version": "0.0.9",
+  "version": "0.0.8",
   "description": "This package generates vuepress compatible markdown from an openapi schema",
   "main": "./dist/openapi-vuepress-markdown.js",
   "repository": "https://github.com/lune-climate/openapi-vuepress-markdown.git",

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -395,6 +395,7 @@ export function generateMarkdownFiles(
     api: OpenAPIV3.Document,
     refs: IRefs,
     outputDirectory?: string,
+    endpointsPrefix?: string,
 ) {
     // resources
     const schemas = api.components?.schemas as Record<string, OpenAPIV3.SchemaObject> | undefined
@@ -410,11 +411,15 @@ export function generateMarkdownFiles(
     const endpoints = generateEndpoints(api, refs)
     const markdownTemplatesData = groupEndpointsByTag(api, endpoints)
     markdownTemplatesData.map((markdownTemplateData) =>
-        generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory),
+        generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory, endpointsPrefix),
     )
 }
 
-function generateEndpointsMarkdownFile(data: MarkdownTemplateData, outputDirectory?: string) {
+function generateEndpointsMarkdownFile(
+    data: MarkdownTemplateData,
+    outputDirectory?: string,
+    endpointsPrefix?: string,
+) {
     const templateContent = readFileSync(path.join(__dirname, '/../endpoints.md'))
     const template = Handlebars.compile(templateContent.toString())
 
@@ -427,7 +432,7 @@ function generateEndpointsMarkdownFile(data: MarkdownTemplateData, outputDirecto
                 .replace(/\s\s+/g, ' ')
                 .replace(/\s/g, '-')
                 .toLowerCase() + '.md'
-        const file = path.join(outputDirectory!, filename)
+        const file = path.join(outputDirectory!, `${endpointsPrefix ?? ''}${filename}`)
         writeFileSync(file, result)
         console.log(`Endpoint saved: ${file}`)
         return

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -394,8 +394,7 @@ function generateResource(
 export function generateMarkdownFiles(
     api: OpenAPIV3.Document,
     refs: IRefs,
-    endpointsDirectory?: string,
-    resourcesDirectory?: string,
+    outputDirectory?: string,
 ) {
     // resources
     const schemas = api.components?.schemas as Record<string, OpenAPIV3.SchemaObject> | undefined
@@ -405,15 +404,13 @@ export function generateMarkdownFiles(
             return generateResource(name, schemaObject, refs)
         },
     )
-    resources.map((resource: Resource) =>
-        generateResourceMarkdownFile(resource, resourcesDirectory),
-    )
+    resources.map((resource: Resource) => generateResourceMarkdownFile(resource, outputDirectory))
 
     // endpoints
     const endpoints = generateEndpoints(api, refs)
     const markdownTemplatesData = groupEndpointsByTag(api, endpoints)
     markdownTemplatesData.map((markdownTemplateData) =>
-        generateEndpointsMarkdownFile(markdownTemplateData, endpointsDirectory),
+        generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory),
     )
 }
 

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -10,25 +10,21 @@ async function main(): Promise<void> {
     program
         .requiredOption('-s, --schema <schema>', 'OpenAPI spec in json or yml format')
         .option(
-            '-e, --endpoints-directory <endpoints-directory>',
-            'Endpoints destination directory. If not specified, then the output is redirected to standard output',
-        )
-        .option(
-            '-r, --resources-directory <resources-directory>',
-            'Resources destination directory. If not specified, then the output is redirected to standard output',
+            '-o, --output-directory <output-directory>',
+            'Output destination directory. If not specified, then the output is redirected to standard output',
         )
         .parse()
         .parse()
 
     const options = program.opts()
-    const { schema, endpointsDirectory, resourcesDirectory } = options
+    const { schema, outputDirectory } = options
 
     const parser = new SwaggerParser()
     // let it throw
     const api = await parser.bundle(schema)
     const refs = parser.$refs
 
-    generateMarkdownFiles(api, refs, endpointsDirectory, resourcesDirectory)
+    generateMarkdownFiles(api, refs, outputDirectory)
 }
 
 // eslint-disable-next-line no-extra-semi

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -13,18 +13,22 @@ async function main(): Promise<void> {
             '-o, --output-directory <output-directory>',
             'Output destination directory. If not specified, then the output is redirected to standard output',
         )
+        .option(
+            '-e, --endpoints-prefix <endpoints-prefix>',
+            'Endpoint file prefix, to avoid filename conflicts with resources. Defaults to blank (no prefix)',
+        )
         .parse()
         .parse()
 
     const options = program.opts()
-    const { schema, outputDirectory } = options
+    const { schema, outputDirectory, endpointsPrefix } = options
 
     const parser = new SwaggerParser()
     // let it throw
     const api = await parser.bundle(schema)
     const refs = parser.$refs
 
-    generateMarkdownFiles(api, refs, outputDirectory)
+    generateMarkdownFiles(api, refs, outputDirectory, endpointsPrefix)
 }
 
 // eslint-disable-next-line no-extra-semi


### PR DESCRIPTION
This is useful in order to avoid naming conflicts between resource and endpoint files.

This is the second attempt to achieve the objective.
Revert previous attempt https://github.com/lune-climate/openapi-vuepress-markdown/pull/9.
