### PR TITLE
Make it possible to link to type members directly

### DIFF
--- a/resource.md
+++ b/resource.md
@@ -10,7 +10,11 @@ sidebarDepth: 0
 {{/inline}}
 
 {{#*inline "row" key property required }}
-| {{ key }} | {{ property.type }}{{> typeDetails key=key property=property required=required}} | {{{ breaklines property.description }}} |
+### {{ key }}
+
+Type: {{ property.type }}{{> typeDetails key=key property=property required=required}}
+
+{{{ breaklines property.description }}}
 {{/inline}}
 
 ## {{ name }}
@@ -18,8 +22,6 @@ sidebarDepth: 0
 {{{ description }}}
 
 {{#if properties}}
-| Field | Type | Description |
-| ----- | ---- | ------------|
 {{#each properties}}
 {{> row key=@key property=this required=../required}}
 {{/each}}


### PR DESCRIPTION
Following the path of least resistance: since link anchors are
automatically added to Markdown section headers we can make the
properties each be its own subsection and that gives us anchors
for free, more or less.

We lose the table structure but I'm not sure if I liked the table
in the first place.

This is an RFC rather than a ready-to-merge PR, some good discussion to be had here I belive.

On thing I'm sure I'd still like to change here is to make the overall structure a bit tighter (so that more information fits on the screen, more like with the table-based solution).

Before:


```
## Project



| Field | Type | Description |
| ----- | ---- | ------------|
| id | string<br />_**required**_ | The projects's unique identifier |
| name | string<br />_**required**_ | The project's name |
| short_name | string<br />_**required**_ | The project's short name. May coincide with name. |
| slug | string<br />_**required**_ | Project slug |
| description | string<br />_**required**_ | Project description |
(...)
```

<img width="793" alt="Screenshot 2022-01-04 at 16 09 50" src="https://user-images.githubusercontent.com/36209/148079914-7cfc4884-c8d8-47cc-a5bb-9a9b15cf6eeb.png">


After:

```
## Project



### id

Type: string<br />_**required**_

The projects's unique identifier
### name

Type: string<br />_**required**_

The project's name
### short_name

Type: string<br />_**required**_

The project's short name. May coincide with name.
### slug

Type: string<br />_**required**_

Project slug
### description

Type: string<br />_**required**_

Project description
(...)
```
<img width="1428" alt="Screenshot 2022-01-04 at 16 10 27" src="https://user-images.githubusercontent.com/36209/148080033-bc6f1bde-6a89-4068-b8cd-73c85ead1183.png">

