### PR TITLE
Supports custom schema parse depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,17 @@
     "commander": "^8.2.0",
     "deepcopy": "^2.1.0",
     "handlebars": "^4.7.7",
+    "openapi-types": "^9.3.0",
     "ramda": "^0.27.1",
     "swagger-parser": "^10.0.3",
-    "openapi-types": "^9.3.0"
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node": "^16.10.2",
     "@types/ramda": "^0.27.45",
     "@types/rewire": "^2.5.28",
+    "@types/validator": "^13.7.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -385,7 +385,6 @@ function generateEndpoint(
         tags: opObject.tags!,
         ...requestBodyObjects(opObject, refs, depth),
         ...(pathParameters ? { pathParameters } : {}),
-        responses: responseObjects(opObject, refs),
         responses: responseObjects(opObject, refs, depth),
     }
 }

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -415,13 +415,13 @@ export function generateMarkdownFiles(
     const resources = sortBy((name: string) => name, Object.keys(schemas ?? {})).map(
         (name: string): Resource => {
             const schemaObject = schemas![name]
-            return generateResource(name, schemaObject, refs, resourceSchemaDepth ?? 2)
+            return generateResource(name, schemaObject, refs, resourceSchemaDepth)
         },
     )
     resources.map((resource: Resource) => generateResourceMarkdownFile(resource, outputDirectory))
 
     // endpoints
-    const endpoints = generateEndpoints(api, refs, endpointsSchemaDepth ?? 2)
+    const endpoints = generateEndpoints(api, refs, endpointsSchemaDepth)
     const markdownTemplatesData = groupEndpointsByTag(api, endpoints)
     markdownTemplatesData.map((markdownTemplateData) =>
         generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory, endpointsPrefix),

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -27,11 +27,11 @@ async function main(): Promise<void> {
         )
         .option(
             '-ed, --endpoint-schema-depth <endpoint-schema-depth>',
-            'Endpoint schema parse depth. Defaults prefix to 2',
+            'Endpoint schema parse depth. Defaults prefix to infinity',
         )
         .option(
             '-rd, --resource-schema-depth <resource-schema-depth>',
-            'Resource schema parse depth. Defaults prefix to 2',
+            'Resource schema parse depth. Defaults prefix to infinity',
         )
         .parse()
 

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -28,11 +28,11 @@ async function main(): Promise<void> {
             'Endpoint file prefix, to avoid filename conflicts with resources. Defaults to blank (no prefix)',
         )
         .option(
-            '-ed, --endpoint-schema-depth <endpoint-schema-depth>',
+            '-d, --endpoint-schema-depth <endpoint-schema-depth>',
             'Endpoint schema parse depth. Defaults prefix to infinity',
         )
         .option(
-            '-rd, --resource-schema-depth <resource-schema-depth>',
+            '-r, --resource-schema-depth <resource-schema-depth>',
             'Resource schema parse depth. Defaults prefix to infinity',
         )
         .parse()

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -3,10 +3,12 @@
 import './handlebarHelpers'
 import { Command } from 'commander'
 import { generateMarkdownFiles } from './markdownAdapters'
+import validator from 'validator'
+
 const SwaggerParser = require('swagger-parser')
 
 function validateNumber(arg: string, name: string): boolean {
-    if (arg && isNaN(Number(arg))) {
+    if (arg && !validator.isInt(arg)) {
         console.log(`${name} must be a number, instead ${arg}`)
         return false
     }

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -32,6 +32,7 @@ describe('markdownAdapters', () => {
     let requestBodyObjects: (
         opObject: Readonly<OpenAPIV3.OperationObject>,
         refs: IRefs,
+        depth: number | undefined,
     ) => {
         requestBodySchema?: OpenAPIV3.SchemaObject
         requestBodyExample?: any
@@ -696,7 +697,7 @@ describe('markdownAdapters', () => {
                 },
             } as unknown as OpenAPIV3.OperationObject
 
-            const requestObjects = requestBodyObjects(opObject, refsMock)
+            const requestObjects = requestBodyObjects(opObject, refsMock, undefined)
 
             expect(refsMock.get).toHaveBeenCalledWith('#/Something')
             expect(requestObjects.requestBodyRef).toBeUndefined()
@@ -783,7 +784,7 @@ describe('markdownAdapters', () => {
                 },
             } as unknown as OpenAPIV3.OperationObject
 
-            const requestObjects = requestBodyObjects(opObject, refsMock)
+            const requestObjects = requestBodyObjects(opObject, refsMock, 2)
 
             expect(refsMock.get).toHaveBeenCalledWith('#/Something')
             expect(requestObjects.requestBodyRef).toBeUndefined()

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,6 +736,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/validator@^13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.1.tgz#cdab1b4779f6b1718a08de89d92d2603b71950cb"
+  integrity sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"


### PR DESCRIPTION
Depending on the endpoint and resource template, we may need to parse the schema to different levels.