### PR TITLE
Parse and render query parameters to markdown

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -56,6 +56,15 @@ Array of:
 {{/each}}
 {{/if}}
 
+{{#if this.queryParameters}}
+#### Query Parameters
+| Field | Type | Description | Example |
+| ----- | ---- | -------- | ----------- | ------- |
+{{#each this.queryParameters}}
+| {{ this.name }} | {{ this.schema.type }} {{#if this.required }}<br />_**required**_{{/if}} | {{{ breaklines this.description }}} | {{ this.schema.example }} |
+{{/each}}
+{{/if}}
+
 {{#if this.requestBodySchema }}
 #### Request Body{{#if this.requestBodyRef }} [{{ refToResourceName this.requestBodyRef }}]({{ refToResourceLink this.requestBodyRef }}){{/if}}:
 {{> schemaMarkdown schema=this.requestBodySchema example=this.requestBodyExample }}

--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -367,6 +367,10 @@ function generateEndpoint(
         (parameter) => parameter.in === 'path',
     )
 
+    const queryParameters = ((opObject.parameters ?? []) as OpenAPIV3.ParameterObject[]).filter(
+        (parameter) => parameter.in === 'query',
+    )
+
     return {
         method,
         path,
@@ -375,6 +379,7 @@ function generateEndpoint(
         tags: opObject.tags!,
         ...requestBodyObjects(opObject, refs),
         ...(pathParameters ? { pathParameters } : {}),
+        ...(queryParameters ? { queryParameters } : {}),
         responses: responseObjects(opObject, refs),
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface Endpoint {
     requestBodyRef?: string
     requestBodyExample?: any
     pathParameters?: OpenAPIV3.ParameterObject[]
+    queryParameters?: OpenAPIV3.ParameterObject[]
     responses: Record<string, ResponseSchema>
 }
 


### PR DESCRIPTION
Query parameters were currently missing.

Fixes https://github.com/lune-climate/openapi-vuepress-markdown/issues/11.