### PR TITLE
Add 'ref' for resolved ReferenceObject objects

### DIFF
--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -155,13 +155,15 @@ function resolveExampleAdditionalProperties(
 function resolveRef(
     schemaOrRefObject: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
     refs: IRefs,
-): OpenAPIV3.SchemaObject {
+): OpenAPIV3.SchemaObject & { ref?: string } {
     const refObject = schemaOrRefObject as OpenAPIV3.ReferenceObject
     if (!refObject.$ref) {
         return deepcopy(schemaOrRefObject as OpenAPIV3.SchemaObject) // make a deepcopy for safety
     }
     const schemaObject = refs.get(refObject.$ref) as OpenAPIV3.SchemaObject
-    return deepcopy(schemaObject) // make a deep copy for safety
+
+    // keep reference in `ref` property if it has been resolved
+    return deepcopy({ ...schemaObject, ref: refObject.$ref }) // make a deep copy for safety
 }
 
 function resolveSchemaOrReferenceObject(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 import { OpenAPIV3 } from 'openapi-types'
 
+type SchemaObjectWithRef = OpenAPIV3.SchemaObject & { ref?: string }
+
 export type ResponseSchema = {
     description?: string
-    schema?: OpenAPIV3.SchemaObject
+    schema?: SchemaObjectWithRef
     ref?: string
     example?: any
 }
@@ -14,7 +16,7 @@ export interface Endpoint {
     tags: string[]
     summary?: string
     description?: string
-    requestBodySchema?: OpenAPIV3.SchemaObject
+    requestBodySchema?: SchemaObjectWithRef
     requestBodyRef?: string
     requestBodyExample?: any
     pathParameters?: OpenAPIV3.ParameterObject[]
@@ -26,8 +28,8 @@ export interface MarkdownTemplateData {
     endpoints: Endpoint[]
 }
 
-export type Properties = Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject>
-export type Resource = { name: string; example?: any } & OpenAPIV3.SchemaObject
+export type Properties = Record<string, SchemaObjectWithRef | OpenAPIV3.ReferenceObject>
+export type Resource = { name: string; example?: any } & SchemaObjectWithRef
 
 export interface IRefs {
     // any: not great, https://github.com/APIDevTools/swagger-parser/blob/main/lib/index.d.ts#L428

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -206,6 +206,7 @@ describe('markdownAdapters', () => {
             expect(refsMock.get).toHaveBeenCalledWith('#/Something')
             expect(schemaObject).toEqual({
                 type: 'object',
+                ref: '#/Something',
                 required: ['a', 'b'],
                 properties: {
                     a: {
@@ -409,6 +410,7 @@ describe('markdownAdapters', () => {
                 },
                 c: {
                     type: 'object',
+                    ref: '#/Something',
                     properties: {
                         z: {
                             type: 'string',
@@ -443,6 +445,7 @@ describe('markdownAdapters', () => {
             expect(refsMock.get).toHaveBeenCalledWith('#/Something')
             expect(schemaObject).toEqual({
                 type: 'object',
+                ref: '#/Something',
                 properties: {
                     c: {
                         type: 'string',
@@ -490,6 +493,7 @@ describe('markdownAdapters', () => {
                     },
                     a: {
                         type: 'object',
+                        ref: '#/Something',
                         properties: {
                             c: {
                                 type: 'string',
@@ -543,6 +547,7 @@ describe('markdownAdapters', () => {
                             example: 'bar',
                         },
                         a: {
+                            ref: '#/Something',
                             type: 'object',
                             properties: {
                                 c: {
@@ -583,6 +588,7 @@ describe('markdownAdapters', () => {
                 type: 'array',
                 items: {
                     type: 'object',
+                    ref: '#/Something',
                     properties: {
                         c: {
                             type: 'string',
@@ -639,6 +645,7 @@ describe('markdownAdapters', () => {
             expect(refsMock.get).toHaveBeenNthCalledWith(3, '#/SomethingElseAgain')
             expect(schemaObject).toEqual({
                 type: 'object',
+                ref: '#/Something',
                 properties: {
                     c: {
                         type: 'string',
@@ -646,6 +653,7 @@ describe('markdownAdapters', () => {
                     },
                     d: {
                         type: 'object',
+                        ref: '#/SomethingElse',
                         properties: {
                             a: {
                                 type: 'string',
@@ -654,6 +662,7 @@ describe('markdownAdapters', () => {
                             b: {
                                 type: 'number',
                                 example: 10,
+                                ref: '#/SomethingElseAgain',
                             },
                         },
                     },
@@ -711,6 +720,7 @@ describe('markdownAdapters', () => {
                     },
                     b: {
                         type: 'object',
+                        ref: '#/Something',
                         properties: {
                             c: {
                                 type: 'string',
@@ -798,6 +808,7 @@ describe('markdownAdapters', () => {
                     },
                     b: {
                         type: 'object',
+                        ref: '#/Something',
                         properties: {
                             c: {
                                 type: 'string',


### PR DESCRIPTION
Resolving ReferenceObjects loses the '$ref' property which holds the name
of the resolved resource.

It may be useful to have the name of the resource when rendering
markdown file.

I've decided to use ref instead of re-adding $ref for two reasons:
1. The $ref property is used to distingish between a fully resolved
   schema object and a reference objects. Therefore re-adding $ref would
   technically make the resolved object unresolved.
2. Better be explicit and distingish between new properties and native
   ones.