### PR TITLE
Add ability to provide custom markdown templates

### DIFF
--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -391,12 +391,21 @@ function generateResource(
     }
 }
 
-export function generateMarkdownFiles(
-    api: OpenAPIV3.Document,
-    refs: IRefs,
-    outputDirectory?: string,
-    endpointsPrefix?: string,
-) {
+export function generateMarkdownFiles({
+    api,
+    refs,
+    outputDirectory,
+    endpointsPrefix,
+    endpointsTemplate,
+    resourceTemplate,
+}: {
+    api: OpenAPIV3.Document
+    refs: IRefs
+    outputDirectory?: string
+    endpointsPrefix?: string
+    endpointsTemplate?: string
+    resourceTemplate?: string
+}) {
     // resources
     const schemas = api.components?.schemas as Record<string, OpenAPIV3.SchemaObject> | undefined
     const resources = sortBy((name: string) => name, Object.keys(schemas ?? {})).map(
@@ -405,13 +414,20 @@ export function generateMarkdownFiles(
             return generateResource(name, schemaObject, refs)
         },
     )
-    resources.map((resource: Resource) => generateResourceMarkdownFile(resource, outputDirectory))
+    resources.map((resource: Resource) =>
+        generateResourceMarkdownFile(resource, outputDirectory, resourceTemplate),
+    )
 
     // endpoints
     const endpoints = generateEndpoints(api, refs)
     const markdownTemplatesData = groupEndpointsByTag(api, endpoints)
     markdownTemplatesData.map((markdownTemplateData) =>
-        generateEndpointsMarkdownFile(markdownTemplateData, outputDirectory, endpointsPrefix),
+        generateEndpointsMarkdownFile(
+            markdownTemplateData,
+            outputDirectory,
+            endpointsPrefix,
+            endpointsTemplate,
+        ),
     )
 }
 
@@ -419,8 +435,10 @@ function generateEndpointsMarkdownFile(
     data: MarkdownTemplateData,
     outputDirectory?: string,
     endpointsPrefix?: string,
+    endpointsTemplate?: string,
 ) {
-    const templateContent = readFileSync(path.join(__dirname, '/../endpoints.md'))
+    const file = endpointsTemplate ?? path.join(__dirname, `/../endpoints.md`)
+    const templateContent = readFileSync(file)
     const template = Handlebars.compile(templateContent.toString())
 
     const result = template(data)
@@ -441,8 +459,13 @@ function generateEndpointsMarkdownFile(
     console.log(result)
 }
 
-function generateResourceMarkdownFile(resource: Resource, outputDirectory?: string) {
-    const templateContent = readFileSync(path.join(__dirname, '/../resource.md'))
+function generateResourceMarkdownFile(
+    resource: Resource,
+    outputDirectory?: string,
+    resourceTemplate?: string,
+) {
+    const file = resourceTemplate ?? path.join(__dirname, `/../resource.md`)
+    const templateContent = readFileSync(file)
     const template = Handlebars.compile(templateContent.toString())
 
     const result = template(resource)

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -17,18 +17,33 @@ async function main(): Promise<void> {
             '-e, --endpoints-prefix <endpoints-prefix>',
             'Endpoint file prefix, to avoid filename conflicts with resources. Defaults to blank (no prefix)',
         )
-        .parse()
+        .option(
+            '-et, --endpoints-template <endpoints-template>',
+            'Endpoints template file. Defaults to ./endpoints.md',
+        )
+        .option(
+            '-rt, --resource-template <resource-template>',
+            'Resource template file. Defaults to ./resource.md',
+        )
         .parse()
 
     const options = program.opts()
-    const { schema, outputDirectory, endpointsPrefix } = options
+    const { schema, outputDirectory, endpointsPrefix, endpointsTemplate, resourceTemplate } =
+        options
 
     const parser = new SwaggerParser()
     // let it throw
     const api = await parser.bundle(schema)
     const refs = parser.$refs
 
-    generateMarkdownFiles(api, refs, outputDirectory, endpointsPrefix)
+    generateMarkdownFiles({
+        api,
+        refs,
+        outputDirectory,
+        endpointsPrefix,
+        endpointsTemplate,
+        resourceTemplate,
+    })
 }
 
 // eslint-disable-next-line no-extra-semi

--- a/src/openapi-vuepress-markdown.ts
+++ b/src/openapi-vuepress-markdown.ts
@@ -18,11 +18,11 @@ async function main(): Promise<void> {
             'Endpoint file prefix, to avoid filename conflicts with resources. Defaults to blank (no prefix)',
         )
         .option(
-            '-et, --endpoints-template <endpoints-template>',
+            '-E, --endpoints-template <endpoints-template>',
             'Endpoints template file. Defaults to ./endpoints.md',
         )
         .option(
-            '-rt, --resource-template <resource-template>',
+            '-R, --resource-template <resource-template>',
             'Resource template file. Defaults to ./resource.md',
         )
         .parse()


### PR DESCRIPTION
endpoints.md and resource.md are default templates.

The new `-rt` and `-et` command line arguments allow us to provide
different templates and therefore generate differently formatted
markdown files.