### PR TITLE
Preserve topmost ref when merging resolveAllOf objects

### DIFF
--- a/src/markdownAdapters.ts
+++ b/src/markdownAdapters.ts
@@ -29,8 +29,8 @@ function mergeSchemaObjects(...schemaObjects: OpenAPIV3.SchemaObject[]): OpenAPI
     return schemaObjects.reduce(
         (currSchemaObject, schemaObject: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject => {
             return {
-                ...currSchemaObject,
                 ...schemaObject,
+                ...currSchemaObject, // add current state after current object: for allOf cases this preserves top level $ref names
                 properties: {
                     ...(currSchemaObject.properties ?? {}),
                     ...(schemaObject.properties ?? {}),

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -671,7 +671,7 @@ describe('markdownAdapters', () => {
             })
         })
 
-        test('should preserve top most refs', () => {
+        test('should preserve topmost refs', () => {
             const refsMock = createIRefsMock()
             refsMock.get.mockImplementation((ref: string) => {
                 switch (ref) {

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -716,7 +716,6 @@ describe('markdownAdapters', () => {
                 0,
             )
 
-            console.log(schemaObject)
             expect(schemaObject).toEqual({
                 type: 'object',
                 properties: {

--- a/test/markdownAdapters.test.ts
+++ b/test/markdownAdapters.test.ts
@@ -677,18 +677,7 @@ describe('markdownAdapters', () => {
                 switch (ref) {
                     case '#/Something':
                         return {
-                            allOf: [
-                                { $ref: '#/SomethingElse' },
-                                {
-                                    type: 'object',
-                                    properties: {
-                                        c: {
-                                            type: 'string',
-                                            example: 'bar',
-                                        },
-                                    },
-                                },
-                            ],
+                            allOf: [{ $ref: '#/SomethingElse' }],
                         }
                     case '#/SomethingElse':
                     default:
@@ -727,10 +716,6 @@ describe('markdownAdapters', () => {
                             d: {
                                 type: 'string',
                                 example: 'foo',
-                            },
-                            c: {
-                                type: 'string',
-                                example: 'bar',
                             },
                         },
                     },


### PR DESCRIPTION
Merging objects through allOf loses context of the inner objects, it is
therefore more meaningful to store the topmost ref instead of the
last.